### PR TITLE
chore: bumping ecs-fargate version for this module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ module aws_cw_logs {
 #------------------------------------------------------------------------------
 module "ecs_fargate" {
   source  = "cn-terraform/ecs-fargate/aws"
-  version = "2.0.20"
+  version = "2.0.21"
   # source = "../terraform-aws-ecs-fargate"
 
   name_prefix                  = "${var.name_prefix}-sonar"


### PR DESCRIPTION
Bumping the version of a recently fixed module for ecs-fargate